### PR TITLE
Update cursor for gif

### DIFF
--- a/style.css
+++ b/style.css
@@ -202,6 +202,7 @@ small.footer a {
   -webkit-user-drag: none;
   -webkit-user-select: none;
   -ms-user-select: none;
+  cursor: grab;
 }
 
 #skew-wrapper {
@@ -219,6 +220,7 @@ small.footer a {
 #gif.dragging {
   transform: scale(0.9, 0.9);
   box-shadow: 0 5px 35px rgba(0, 0, 0, 0.5);
+  cursor: grabbing;
 }
 
 @keyframes bumpHorizontal {


### PR DESCRIPTION
This pull request introduces minor improvements to the user interface by enhancing the cursor behavior for draggable elements in the `style.css` file.

* **Cursor behavior updates for draggable elements:**
  - Added a `cursor: grab` style to the `#gif` selector to indicate draggable elements when not actively being dragged.
  - Added a `cursor: grabbing` style to the `#gif.dragging` selector to visually indicate when an element is being dragged.